### PR TITLE
Fix define-library form and problem with loading in Chibi

### DIFF
--- a/srfi-223.html
+++ b/srfi-223.html
@@ -28,7 +28,6 @@
 
 <ul>
   <li>Whether syntax to define bisect-left and bisect-right for a particular sequence type, with potential automatic setting of lo and hi, would be a useful thing to provide.
-  <li>The sample implementation won’t load in Chibi Scheme for as-yet inscrutable reasons.
 </ul>
 
 <h2 id="rationale">Rationale</h2>

--- a/srfi-223.sld
+++ b/srfi-223.sld
@@ -1,4 +1,4 @@
-(define-library (bisect)
+(define-library (srfi-223)
   (import (scheme base)
           (scheme case-lambda))
 
@@ -6,4 +6,4 @@
           vector-bisect-left vector-bisect-right
           bytevector-bisect-left bytevector-bisect-right)
 
-  (load "bisect.scm"))
+  (include "srfi-223.scm"))


### PR DESCRIPTION
Asked Alex Shinn on #scheme and he said to use `include` and not `load` to pull the `.scm` file into the `.sld`. That indeed seems to fix the issue.

Also fixed the define-library form to match the new name of the `.sld` file.

(I assume we don’t need to publish a new draft just to remove mention of an issue which affected the sample implementation?)