### PR TITLE
Second draft

### DIFF
--- a/srfi-223.html
+++ b/srfi-223.html
@@ -115,7 +115,7 @@
 
 <h2 id="copyright">Copyright</h2>
 <p>&copy; 2021 Daphne Preston-Kendal (text and sample implementation in Scheme). <br>
-&copy; 1998–2020 Python Software Foundation (guideline algorithm implementation in Python).</p>
+&copy; 1992–2019 Python Software Foundation (guideline algorithm implementation in Python).</p>
 
 <p>
   Permission is hereby granted, free of charge, to any person

--- a/srfi-223.html
+++ b/srfi-223.html
@@ -27,7 +27,7 @@
 <h2 id="issues">Issues</h2>
 
 <ul>
-  <li>Whether syntax to define bisect-left and bisect-right for a particular sequence type, with potential automatic setting of lo and hi, would be a useful thing to provide.
+  <li>Whether there is a better alternative than providing <code>define-bisection</code> as syntax.
 </ul>
 
 <h2 id="rationale">Rationale</h2>
@@ -53,6 +53,8 @@
 
 <h3 id=generalized-procedures>Generalized procedures</h3>
 
+<p>The following procedures must work when used, with suitable <var>ref</var>, <var>lo</var>, and <var>hi</var> arguments, on sequence types which define negative indexes.
+
 <dl>
   <dt><code>(bisect-left</code> <var>a</var> <var>val</var> <var>ref</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
     <dd>Searches the sequence <var>a</var> for the value <var>val</var>, returning an index <var>idx</var> into <var>a</var> such that all elements with indexes ≥ <var>idx</var> are all ≥ <var>val</var>. In other words, returns the leftmost index in <var>a</var> of <var>val</var> or anything which is less than it. Returns <var>lo</var> if <var>val</var> is less than everything in <var>a</var>.
@@ -60,33 +62,38 @@
     <dd>Searches the sequence <var>a</var> for the value <var>val</var>, returning an index <var>idx</var> into <var>a</var> such that all elements with indexes &lt; <var>idx</var> are all &lt; <var>val</var>. In other words, returns an index in <var>a</var> which is to the right of (i.e. after) <var>val</var> or anything less than it. Returns <var>hi</var> if <var>val</var> is greater than everything in <var>a</var>.
 </dl>
 
+<h3 id=syntax>Convenience syntax</h3>
+
+<p>Defining both <code>*-bisect-left</code> and <code>*-bisect-right</code> procedures for a given type, and handling the optionality of <var>lo</var> and <var>hi</var> correctly, can make code very repetitive. To ease this repetition, the following convenience syntax is provided.
+
+<dl>
+  <dt><code>(define-bisection</code> <var>bisect-left-name</var> <var>bisect-right-name</var> <var>ref</var><code>)</code>
+  <dt><code>(define-bisection</code> <var>bisect-left-name</var> <var>bisect-right-name</var> <var>ref</var> <var>lo-hi-proc</var><code>)</code>
+    <dd>Defines <var>bisect-left-name</var> and <var>bisect-right-name</var> to be procedures of the form <code>(</code><var>bisect-*-name</var> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var>)</code>, which call the <code>bisect-left</code> and <code>bisect-right</code> procedures with the given <var>ref</var> procedure, comparable to <code>vector-bisect-left</code> and <code>vector-bisect-right</code> on vectors. If the <var>lo-hi-proc</var> argument is given, it should be a procedure which takes one argument, a sequence <val>a</val>, and returns two values, the default <var>lo</var> and <var>hi</var> values for that sequence (usually 0 and the length of the sequence). If no <var>lo-hi-proc</var> procedure is given, the <var>lo</var> and <var>hi</var> arguments to the defined procedures are mandatory.
+</dl>
+
 <h3 id=vector-procedures>Vector procedures</h3>
 
 <dl>
   <dt><code>(vector-bisect-left</code> <var>a</var> <var>val</var> <var>less?</var><code>)</code> ⇒ <var>idx</var>
-  <dt><code>(vector-bisect-left</code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var><code>)</code> ⇒ <var>idx</var>
   <dt><code>(vector-bisect-left</code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
     <dd>Searches the vector <var>a</var> using <code>bisect-left</code>.
   <dt><code>(vector-bisect-right</code> <var>a</var> <var>val</var> <var>less?</var><code>)</code> ⇒ <var>idx</var>
-  <dt><code>(vector-bisect-right</code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var><code>)</code> ⇒ <var>idx</var>
   <dt><code>(vector-bisect-right</code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
     <dd>Searches the vector <var>a</var> using <code>bisect-right</code>.
 </dl>
 
-<h3 id=bytevector-procedures>Bytevector procedures</h3>
-
-<dl>
-  <dt><code>(bytevector-bisect-left</code> <var>a</var> <var>val</var><code>)</code> ⇒ <var>idx</var>
-  <dt><code>(bytevector-bisect-left</code> <var>a</var> <var>val</var> <var>lo</var><code>)</code> ⇒ <var>idx</var>
-  <dt><code>(bytevector-bisect-left</code> <var>a</var> <var>val</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
-    <dd>Searches the bytevector <var>a</var> using <code>bisect-left</code> with the standard <code>&lt;</code> comparison procedure.
-  <dt><code>(bytevector-bisect-right</code> <var>a</var> <var>val</var><code>)</code> ⇒ <var>idx</var>
-  <dt><code>(bytevector-bisect-right</code> <var>a</var> <var>val</var> <var>lo</var><code>)</code> ⇒ <var>idx</var>
-  <dt><code>(bytevector-bisect-right</code> <var>a</var> <var>val</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
-    <dd>Searches the bytevector <var>a</var> using <code>bisect-right</code> with the standard <code>&lt;</code> comparison procedure.
-</dl>
-
 <h2 id=example>Example usage</h2>
+
+<h3>Defining a new bisection</h3>
+
+<p>Bisect procedures which operate on Scheme bytevectors can be defined concisely with the following code.
+
+<pre><code>(define-bisection bytevector-bisect-left bytevector-bisect-right
+  bytevector-u8-ref
+  (lambda (bv) (values 0 (bytevector-length bv))))</code></pre>
+
+<h3>Bisecting a vector</h3>
 
 <table>
   <tr>
@@ -103,7 +110,7 @@
     <td>⇒ <code>1</code>
 </table>
 
-<p>Or the same results changing the example vector to a bytevector and using the <code>bytevector-bisect-left/right</code> procedures with no <code>&lt;</code> argument.
+<p>Or with the example bytevector bisection defined above, one could change the procedures here to their corresponding bytevector versions, and the vectors also to bytevectors, and get the same results.
 
 <h2 id="implementation">Implementation</h2>
 

--- a/srfi-223.html
+++ b/srfi-223.html
@@ -26,9 +26,7 @@
 
 <h2 id="issues">Issues</h2>
 
-<ul>
-  <li>Whether there is a better alternative than providing <code>define-bisection</code> as syntax.
-</ul>
+<p>No issues at present.
 
 <h2 id="rationale">Rationale</h2>
 
@@ -62,14 +60,32 @@
     <dd>Searches the sequence <var>a</var> for the value <var>val</var>, returning an index <var>idx</var> into <var>a</var> such that all elements with indexes &lt; <var>idx</var> are all &lt; <var>val</var>. In other words, returns an index in <var>a</var> which is to the right of (i.e. after) <var>val</var> or anything less than it. Returns <var>hi</var> if <var>val</var> is greater than everything in <var>a</var>.
 </dl>
 
-<h3 id=syntax>Convenience syntax</h3>
+<h3 id=convenience>Convenience procedure</h3>
 
-<p>Defining both <code>*-bisect-left</code> and <code>*-bisect-right</code> procedures for a given type, and handling the optionality of <var>lo</var> and <var>hi</var> correctly, can make code very repetitive. To ease this repetition, the following convenience syntax is provided.
+<p>Defining both <code>*-bisect-left</code> and <code>*-bisect-right</code> procedures for a given type, and handling the optionality of <var>lo</var> and <var>hi</var> correctly, can make code very repetitive. To ease this repetition, the following convenience procedure is provided.
 
 <dl>
-  <dt><code>(define-bisection</code> <var>bisect-left-name</var> <var>bisect-right-name</var> <var>ref</var><code>)</code>
-  <dt><code>(define-bisection</code> <var>bisect-left-name</var> <var>bisect-right-name</var> <var>ref</var> <var>lo-hi-proc</var><code>)</code>
-    <dd>Defines <var>bisect-left-name</var> and <var>bisect-right-name</var> to be procedures of the form <code>(</code><var>bisect-*-name</var> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var>)</code>, which call the <code>bisect-left</code> and <code>bisect-right</code> procedures with the given <var>ref</var> procedure, comparable to <code>vector-bisect-left</code> and <code>vector-bisect-right</code> on vectors. If the <var>lo-hi-proc</var> argument is given, it should be a procedure which takes one argument, a sequence <val>a</val>, and returns two values, the default <var>lo</var> and <var>hi</var> values for that sequence (usually 0 and the length of the sequence). If no <var>lo-hi-proc</var> procedure is given, the <var>lo</var> and <var>hi</var> arguments to the defined procedures are mandatory.
+  <dt><code>(bisection</code> <var>ref</var><code>)</code>
+    ⇒
+    <span style="display: inline-block; vertical-align: middle;">
+      1 <code>(<var>left-proc</var></code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code> <br>
+      2 <code>(<var>right-proc</var></code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code>
+    </span>
+  <dt><code>(bisection</code> <var>ref</var> <var>lo-hi-proc</var><code>)</code>
+    ⇒
+    <span style="display: inline-block; vertical-align: middle;">
+      1
+      <span style="display: inline-block; vertical-align: middle;">
+        <code>(<var>left-proc</var></code> <var>a</var> <var>val</var> <var>less?</var><code>)</code> <br>
+        <code>(<var>left-proc</var></code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code>
+      </span> <br>
+      2
+      <span style="display: inline-block; vertical-align: middle; margin-top: 0.5em;">
+        <code>(<var>right-proc</var></code> <var>a</var> <var>val</var> <var>less?</var><code>)</code> <br>
+        <code>(<var>right-proc</var></code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code>
+      </span>
+    </span>
+    <dd>Returns two values, procedures which call <code>bisect-left</code> and <code>bisect-right</code> respectively with the given <var>ref</var> procedure, comparable to <code>vector-bisect-left</code> and <code>vector-bisect-right</code> for vectors. If the <var>lo-hi-proc</var> argument is given, it should be a procedure which takes one argument, a sequence <var>a</var>, and returns two values, the default <var>lo</var> and <var>hi</var> values for that sequence (usually 0 and the length of the sequence). If no <var>lo-hi-proc</var> procedure is given, the <var>lo</var> and <var>hi</var> arguments to the returned procedures are mandatory.
 </dl>
 
 <h3 id=vector-procedures>Vector procedures</h3>
@@ -89,9 +105,9 @@
 
 <p>Bisect procedures which operate on Scheme bytevectors can be defined concisely with the following code.
 
-<pre><code>(define-bisection bytevector-bisect-left bytevector-bisect-right
-  bytevector-u8-ref
-  (lambda (bv) (values 0 (bytevector-length bv))))</code></pre>
+<pre><code>(define-values (bytevector-bisect-left bytevector-bisect-right)
+  (bisection bytevector-u8-ref
+             (lambda (bv) (values 0 (bytevector-length bv)))))</code></pre>
 
 <h3>Bisecting a vector</h3>
 

--- a/srfi-223.scm
+++ b/srfi-223.scm
@@ -12,28 +12,25 @@
             (bisect-left a val ref less? lo mid)
             (bisect-left a val ref less? (+ mid 1) hi)))))
 
-(define-syntax define-bisection
-  (syntax-rules ()
-    ((_ bisect-left-name bisect-right-name ref-proc lo-hi-proc)
-     (begin
-       (define bisect-left-name
-         (case-lambda
-          ((a val less?)
-           (let-values (((lo hi) (lo-hi-proc a)))
-             (bisect-left a val ref-proc less? lo hi)))
-          ((a val less? lo hi)
-           (bisect-left a val ref-proc less? lo hi))))
-       (define bisect-right-name
-         (case-lambda
-          ((a val less?)
-           (let-values (((lo hi) (lo-hi-proc a)))
-             (bisect-right a val ref-proc less? lo hi)))
-          ((a val less? lo hi)
-           (bisect-right a val ref-proc less? lo hi))))))
-    ((_ bisect-left-name bisect-right-name ref-proc)
-     (define-bisection bisect-left-name bisect-right-name
-       ref-proc
-       (lambda (a) (error "both lo and hi arguments must be given to this procedure"))))))
+(define bisection
+  (case-lambda
+    ((ref lo-hi-proc)
+     (values
+      (case-lambda
+       ((a val less?)
+        (let-values (((lo hi) (lo-hi-proc a)))
+          (bisect-left a val ref less? lo hi)))
+       ((a val less? lo hi)
+        (bisect-left a val ref less? lo hi)))
+      (case-lambda
+       ((a val less?)
+        (let-values (((lo hi) (lo-hi-proc a)))
+          (bisect-right a val ref less? lo hi)))
+       ((a val less? lo hi)
+        (bisect-right a val ref less? lo hi)))))
+  ((ref)
+   (bisection ref
+              (lambda (a) (error "both lo and hi arguments must be given to this procedure"))))))
 
-(define-bisection vector-bisect-left vector-bisect-right
-  vector-ref (lambda (v) (values 0 (vector-length v))))
+(define-values (vector-bisect-left vector-bisect-right)
+  (bisection vector-ref (lambda (v) (values 0 (vector-length v)))))

--- a/srfi-223.scm
+++ b/srfi-223.scm
@@ -12,38 +12,28 @@
             (bisect-left a val ref less? lo mid)
             (bisect-left a val ref less? (+ mid 1) hi)))))
 
-(define vector-bisect-left
-  (case-lambda
-   ((a val less?)
-    (vector-bisect-left a val less? 0 (vector-length a)))
-   ((a val less? lo)
-    (vector-bisect-left a val less? lo (vector-length a)))
-   ((a val less? lo hi)
-    (bisect-left a val vector-ref less? lo hi))))
+(define-syntax define-bisection
+  (syntax-rules ()
+    ((_ bisect-left-name bisect-right-name ref-proc lo-hi-proc)
+     (begin
+       (define bisect-left-name
+         (case-lambda
+          ((a val less?)
+           (let-values (((lo hi) (lo-hi-proc a)))
+             (bisect-left a val ref-proc less? lo hi)))
+          ((a val less? lo hi)
+           (bisect-left a val ref-proc less? lo hi))))
+       (define bisect-right-name
+         (case-lambda
+          ((a val less?)
+           (let-values (((lo hi) (lo-hi-proc a)))
+             (bisect-right a val ref-proc less? lo hi)))
+          ((a val less? lo hi)
+           (bisect-right a val ref-proc less? lo hi))))))
+    ((_ bisect-left-name bisect-right-name ref-proc)
+     (define-bisection bisect-left-name bisect-right-name
+       ref-proc
+       (lambda (a) (error "both lo and hi arguments must be given to this procedure"))))))
 
-(define vector-bisect-right
-  (case-lambda
-   ((a val less?)
-    (vector-bisect-right a val less? 0 (vector-length a)))
-   ((a val less? lo)
-    (vector-bisect-right a val less? lo (vector-length a)))
-   ((a val less? lo hi)
-    (bisect-right a val vector-ref less? lo hi))))
-
-(define bytevector-bisect-left
-  (case-lambda
-   ((a val)
-    (bytevector-bisect-left a val 0 (bytevector-length a)))
-   ((a val lo)
-    (bytevector-bisect-left a val lo (bytevector-length a)))
-   ((a val lo hi)
-    (bisect-left a val bytevector-u8-ref < lo hi))))
-
-(define bytevector-bisect-right
-  (case-lambda
-   ((a val)
-    (bytevector-bisect-right a val 0 (bytevector-length a)))
-   ((a val lo)
-    (bytevector-bisect-right a val lo (bytevector-length a)))
-   ((a val lo hi)
-    (bisect-right a val bytevector-u8-ref < lo hi))))
+(define-bisection vector-bisect-left vector-bisect-right
+  vector-ref (lambda (v) (values 0 (vector-length v))))

--- a/srfi-223.sld
+++ b/srfi-223.sld
@@ -3,7 +3,7 @@
           (scheme case-lambda))
 
   (export bisect-left bisect-right
-          vector-bisect-left vector-bisect-right
-          bytevector-bisect-left bytevector-bisect-right)
+          define-bisection
+          vector-bisect-left vector-bisect-right)
 
   (include "srfi-223.scm"))

--- a/srfi-223.sld
+++ b/srfi-223.sld
@@ -3,7 +3,7 @@
           (scheme case-lambda))
 
   (export bisect-left bisect-right
-          define-bisection
+          bisection
           vector-bisect-left vector-bisect-right)
 
   (include "srfi-223.scm"))


### PR DESCRIPTION
To quote the commit message, which adequately summarizes the changes:

> Deleted bytevector-bisect-* procedures, as they're probably unlikely
> to be useful in practice. In their place, I show how to use the new
> define-bisection syntax to get them back. The sample implementation
> now also uses the new define-bisection syntax to define the procedures
> on vectors.

I’d like to offer a bit of commentary on this and on the new issue listed in the ‘issues’ section for the mailing list to discuss.

Providing syntax for `define-bisection` seems like overkill, and probably is. I’d much prefer a procedure, `bisection`, which would return two values, the procedure for the left bisection and the right bisection respectively. However, there would then be no elegant way to bind those to names at the top level in R7RS small, as R7RS small has no `define-values` (nor does R6RS or R5RS, and although some implementations define it and a Google search for [site:srfi.schemers.org "define-values"] shows it’s been used to demonstrate some SRFIs, it apparently hasn’t been standardized. [Footnote: It would be extremely useful to have a symbol index to all SRFIs so we can look up what defines what without resorting to Google.]). In order to get them at the top level, you’d have to do something like this:

```scheme
(define x-bisect-left #f)
(define x-bisect-right #f)

(let-values (((left-proc right-proc) (bisection x-ref)))
  ;; This is a new lexical environment, so we can’t put the define forms directly
  ;; here or they’ll be treated as local to the let, and not bound at the top level.
  ;; The same applies to any other method of capturing multiple return values
  ;; provided by R7RS small.
  (set! x-bisect-left left-proc)
  (set! x-bisect-right right-proc))
```

However inelegant it is to define syntax for this one case, I’m sure everyone can agree the above is far worse. The ideal is:

```scheme
(define-values (x-bisect-left x-bisect-right) (bisection x-ref))
```

One option would be separate `left-bisection` and `right-bisection` procedures returning one procedure each. But that still means repeating not only the ref-proc, but also the lo-hi-proc (likely a lambda) if one is provided (and I expect one will be in most cases, as most vectors have a known size), and I’d rather force (or at least encourage) people to be consistent about always defining the right bisection if they define the left, and vice-versa.

As the point of providing this is convenience, I think I’d like to provide the most convenient possible thing — and the most convenient *possible* thing (emphasis deliberate) is a `define-bisection` special form. But I’m open to other ideas.