### PR TITLE
Third draft

### DIFF
--- a/srfi-223.html
+++ b/srfi-223.html
@@ -140,7 +140,7 @@
 
 <pre><code>(define (vector-bisect-index a val cmpr)
   (let ((idx (vector-bisect-left a val (comparator-ordering-predicate cmpr))))
-    (if (and (< idx (vector-length a))
+    (if (and (&lt; idx (vector-length a))
              (=? cmpr val (vector-ref a idx)))
         idx
      #f)))</code></pre>

--- a/srfi-223.html
+++ b/srfi-223.html
@@ -128,9 +128,20 @@
 
 <p>Or with the example bytevector bisection defined above, one could change the procedures here to their corresponding bytevector versions, and the vectors also to bytevectors, and get the same results.
 
+<h3>Use with <a href="https://srfi.schemers.org/srfi-128/srfi-128.html">SRFI 128</a> comparators</h3>
+
+<p>The following code shows how to define a procedure <code>vector-bisect-index</code> which returns the smallest index of <var>val</var> in the vector <var>a</var>, or <code>#f</code> if <var>val</var> is not actually in <var>a</var>, according to the given SRFI 128 comparator <var>cmpr</var>.
+
+<pre><code>(define (vector-bisect-index a val cmpr)
+  (let ((idx (vector-bisect-left a val (comparator-ordering-predicate cmpr))))
+    (if (and (< idx (vector-length a))
+             (=? cmpr val (vector-ref a idx)))
+        idx
+     #f)))</code></pre>
+
 <h2 id="implementation">Implementation</h2>
 
-<p>The sample implementation in the <a href="https://github.com/scheme-requests-for-implementation/srfi-223">Git repository for this SRFI</a> should be correct and work on all compliant R7RS small implementations, although programmers working on Schemes with 32-bit word size, no automatic promotion of the results of <code>+</code> to bignums, and very large sequences (typically more than a gibi-entry or so in size, depending on fixnum range) should be aware of the possibility of integer overflow. See Joshua Bloch, <a href="https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html">‘Extra, Extra — Read All About It: Nearly All Binary Searches and Mergesorts are Broken’</a>. Supporting Scheme systems without automatic bignum promotion is not a goal of the sample implementation.
+<p>The sample implementation in the <a href="https://github.com/scheme-requests-for-implementation/srfi-223">Git repository for this SRFI</a> should be correct and work on all compliant R7RS small implementations, although programmers working on Schemes with no automatic promotion of the results of <code>+</code> to bignums and very large sequences (typically more than a gibi-entry or so in size, depending on fixnum range) should be aware of the possibility of integer overflow. See Joshua Bloch, <a href="https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html">‘Extra, Extra — Read All About It: Nearly All Binary Searches and Mergesorts are Broken’</a>. Supporting Scheme systems without automatic bignum promotion is not a goal of the sample implementation.
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 

--- a/srfi-223.html
+++ b/srfi-223.html
@@ -30,7 +30,7 @@
 
 <h2 id="rationale">Rationale</h2>
 
-<p>While SRFIs <a href="https://srfi.schemers.org/srfi-43/srfi-43.html">43</a> and <a href="https://srfi.schemers.org/srfi-133/srfi-133.html">133</a> provide a <code>vector-binary-search</code> procedure, in neither SRFI is the option provided to control whether the index of the leftmost or rightmost matching element of the vector is returned. They also use a C-style <code>cmp</code> procedure which is incompatible with the less-than comparison predicate used by <a href="https://srfi.schemers.org/srfi-132/srfi-132.html">SRFI 132</a> for sorting lists and vectors (such as might be used to make one ready for binary search). Finally, <code>vector-binary-search</code>, as the name implies, can only be used on Scheme vectors. Use on other sequence types, such as bytevectors, is not foreseen.
+<p>While SRFIs <a href="https://srfi.schemers.org/srfi-43/srfi-43.html">43</a> and <a href="https://srfi.schemers.org/srfi-133/srfi-133.html">133</a> provide a <code>vector-binary-search</code> procedure, in neither SRFI is the option provided to control whether the index of the leftmost or rightmost matching element of the vector is returned. They also use a C-style <code>cmp</code> procedure which is incompatible neither with the less-than comparison predicate used by <a href="https://srfi.schemers.org/srfi-132/srfi-132.html">SRFI 132</a> for sorting lists and vectors (such as might be used to make one ready for binary search), nor with <a href="https://srfi.schemers.org/srfi-128/srfi-128.html">SRFI 128</a> comparator ordering predicates. Finally, <code>vector-binary-search</code>, as the name implies, can only be used on Scheme vectors. Use on other sequence types, such as the homogenous numeric vectors of <a href="https://srfi.schemers.org/srfi-160/srfi-160.html">SRFI 160</a>, is not foreseen.
 
 <p>As binary search is notoriously tricky to implement correctly (especially in light of its apparent simplicity), a correct implementation which is generalizable to any sequence type (including one that a programmer might define themselves) is a useful building block for fast search applications.
 
@@ -134,7 +134,7 @@
 
 <p>Or with the example bytevector bisection defined above, one could change the procedures here to their corresponding bytevector versions, and the vectors also to bytevectors, and get the same results.
 
-<h3>Use with <a href="https://srfi.schemers.org/srfi-128/srfi-128.html">SRFI 128</a> comparators</h3>
+<h3>Use with SRFI 128 comparators</h3>
 
 <p>The following code shows how to define a procedure <code>vector-bisect-index</code> which returns the smallest index of <var>val</var> in the vector <var>a</var>, or <code>#f</code> if <var>val</var> is not actually in <var>a</var>, according to the given SRFI 128 comparator <var>cmpr</var>.
 

--- a/srfi-223.html
+++ b/srfi-223.html
@@ -41,23 +41,23 @@
 <p>In the following procedure specifications, the following variable names are used as procedure arguments having a particular meaning:
 
 <ul>
-  <li><dfn><var>a</var></dfn> is a sequence which should be searched.
-  <li><dfn><var>val</var></dfn> is the object which will be searched for within the sequence <var>a</var>.
-  <li><dfn><var>ref</var></dfn> is a procedure taking two arguments, <var>a</var> and <var>i</var>, which returns the object at index <var>i</var> in <var>a</var>.
-  <li><dfn><var>less?</var></dfn> is a procedure taking two arguments and returning <code>#t</code> if the first is strictly less than the second, or otherwise <code>#f</code>.
+  <li><dfn><var>a</var></dfn> is a sorted sequence which should be searched.
+  <li><dfn><var>val</var></dfn> is the value which will be searched for within the sequence <var>a</var>.
+  <li><dfn><var>ref</var></dfn> is a procedure taking two arguments, <var>a</var> and <var>i</var>, which returns the object at index <var>i</var> in <var>a</var>. It is the programmer’s responsibility to ensure that <var>ref</var> can correctly obtained indexed values for a given sequence <var>a</var>. (Thus, it is an error to pass <code>bytevector-u8-ref</code> as <var>ref</var> when <var>a</var> is a vector.)
+  <li><dfn><var>less?</var></dfn> is a procedure taking two arguments and returning <code>#t</code> if the first is strictly less than the second according to the sort order of the sequence <var>a</var>, or otherwise <code>#f</code>. It is the programmer’s responsibility to ensure that <var>less?</var> can handle comparisons between the given <var>val</var> and any value present in the sequence <var>a</var>; that the order of items in given sequence <var>a</var> actually corresponds to the behaviour of the given <var>less?</var>; and that it is irreflexive, antisymmetric, and transitive, yielding a total ordering of all values in its domain.
   <li><dfn><var>lo</var></dfn> is the lowest (i.e. leftmost) index into <var>a</var> from which the search should be made. If optional and not provided, defaults to 0.
-  <li><dfn><var>hi</var></dfn> is the one more than the highest (i.e. rightmost) index into <var>a</var> to which the search should be made.  If optional and not provided, defaults to the length of the sequence.
+  <li><dfn><var>hi</var></dfn> is the one more than the highest (i.e. rightmost) index into <var>a</var> to which the search should be made. If optional and not provided, defaults to the length of the sequence.
 </ul>
 
 <h3 id=generalized-procedures>Generalized procedures</h3>
 
-<p>The following procedures must work when used, with suitable <var>ref</var>, <var>lo</var>, and <var>hi</var> arguments, on sequence types which define negative indexes.
+<p>The following procedures must work when used, with suitable <var>ref</var>, <var>lo</var>, and <var>hi</var> arguments, on sequence types which define negative indexes. (This does not refer to the potential use of negative indexes to refer to items in a sequence counting from the last item rather than the first, but rather sequences where negative indexes refer to unique positions in the sequence.)
 
 <dl>
   <dt><code>(bisect-left</code> <var>a</var> <var>val</var> <var>ref</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
-    <dd>Searches the sequence <var>a</var> for the value <var>val</var>, returning an index <var>idx</var> into <var>a</var> such that all elements with indexes ≥ <var>idx</var> are all ≥ <var>val</var>. In other words, returns the leftmost index in <var>a</var> of <var>val</var> or anything which is less than it. Returns <var>lo</var> if <var>val</var> is less than everything in <var>a</var>.
+    <dd>Searches the sequence <var>a</var> for the value <var>val</var>, returning the smallest index <var>idx</var> into <var>a</var> such that all elements with indexes ≥ <var>idx</var> are all ≥ <var>val</var>. In other words, returns the leftmost index in <var>a</var> of <var>val</var> or anything which is less than it. Returns <var>lo</var> if <var>val</var> is less than everything in <var>a</var>.
   <dt><code>(bisect-right</code> <var>a</var> <var>val</var> <var>ref</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
-    <dd>Searches the sequence <var>a</var> for the value <var>val</var>, returning an index <var>idx</var> into <var>a</var> such that all elements with indexes &lt; <var>idx</var> are all &lt; <var>val</var>. In other words, returns an index in <var>a</var> which is to the right of (i.e. after) <var>val</var> or anything less than it. Returns <var>hi</var> if <var>val</var> is greater than everything in <var>a</var>.
+    <dd>Searches the sequence <var>a</var> for the value <var>val</var>, returning the largest index <var>idx</var> into <var>a</var> such that all elements with indexes &lt; <var>idx</var> are all &lt; <var>val</var>. In other words, returns an index in <var>a</var> which is to the right of (i.e. after) <var>val</var> or anything less than it. Returns <var>hi</var> if <var>val</var> is greater than everything in <var>a</var>.
 </dl>
 
 <h3 id=convenience>Convenience procedure</h3>
@@ -98,6 +98,12 @@
   <dt><code>(vector-bisect-right</code> <var>a</var> <var>val</var> <var>less?</var> <var>lo</var> <var>hi</var><code>)</code> ⇒ <var>idx</var>
     <dd>Searches the vector <var>a</var> using <code>bisect-right</code>.
 </dl>
+
+<h3 id=library-names>Library names</h3>
+
+<p>All procedures provided by this SRFI are in the library called <code>(srfi 223)</code>, <i lang=la>mutatis mutandis</i>.
+
+<p>Implementations and future RnRS specifications should, if they adopt this SRFI, specify analagous <code>*-bisect-left</code> and <code>*-bisect-right</code> procedures for all sequence types they provide which offer O(1) or ‘effectively O(1)’ access time, and in which sorted data may reasonably be expected to appear; but they should do under another library name, and the library <code>(srfi 223)</code> must contain only the procedures directly specified here. They may also choose to divide the core, generalized procedures of this library (<code>bisect-left</code>, <code>bisect-right</code>, and <code>bisection</code>) into one library (such as <code>(xyz bisect)</code>) and make each application of those procedures to specific sequence types their own sublibrary (such as <code>(xyz bisect vector)</code>, <code>(xyz bisect flexvector)</code>, etc.)
 
 <h2 id=example>Example usage</h2>
 

--- a/srfi-223.scm
+++ b/srfi-223.scm
@@ -9,8 +9,8 @@
   (if (>= lo hi) lo
       (let ((mid (floor-quotient (+ lo hi) 2)))
         (if (less? val (ref a mid))
-            (bisect-left a val ref less? lo mid)
-            (bisect-left a val ref less? (+ mid 1) hi)))))
+            (bisect-right a val ref less? lo mid)
+            (bisect-right a val ref less? (+ mid 1) hi)))))
 
 (define bisection
   (case-lambda

--- a/srfi-223.scm
+++ b/srfi-223.scm
@@ -28,9 +28,9 @@
           (bisect-right a val ref less? lo hi)))
        ((a val less? lo hi)
         (bisect-right a val ref less? lo hi)))))
-  ((ref)
-   (bisection ref
-              (lambda (a) (error "both lo and hi arguments must be given to this procedure"))))))
+    ((ref)
+     (bisection ref
+                (lambda (a) (error "both lo and hi arguments must be given to this procedure"))))))
 
 (define-values (vector-bisect-left vector-bisect-right)
   (bisection vector-ref (lambda (v) (values 0 (vector-length v)))))

--- a/test.scm
+++ b/test.scm
@@ -1,4 +1,5 @@
 (import (scheme base))
+(import (scheme case-lambda))
 (import (scheme division))
 (import (scheme inexact))
 
@@ -19,7 +20,15 @@
   (test "left bisection for n for the nth inverted triangular number ≥ x."
         3 (bisect-left #f 2 inverted-triangular-ref < 0 100))
   (test "right bisection for n for the nth inverted triangular number < x."
-        6 (bisect-right #f 2 inverted-triangular-ref < 0 100)))
+        6 (bisect-right #f 2 inverted-triangular-ref < 0 100))
+
+  ;; test for integer overflow
+  (test "left bisection for a massive sequence size"
+        68719439628
+        (bisect-left #f 370727 inverted-triangular-ref < 0 (expt 2 48)))
+  (test "right bisection for a massive sequence size"
+        68719810356
+        (bisect-right #f 370727 inverted-triangular-ref < 0 (expt 2 48))))
 
 (test-group "Bisections over vectors"
   (test "left bisection over a vector"
@@ -28,10 +37,47 @@
         3 (vector-bisect-right #(1 2 2 3 5) 2 <)))
 
 (test-group "Bisections over vectors of things other than numbers"
-  (test "left bisection over a vector of characters"
+  (test "basic left bisection over a vector of characters"
         1 (vector-bisect-left #(#\A #\Z #\a #\z) #\B char<?))
-  (test "right bisection over a vector of characters"
+  (test "basic right bisection over a vector of characters"
         2 (vector-bisect-right #(#\A #\Z #\a #\z) #\Z char<?)))
+
+;; These tests, meant to ensure that everything works properly on
+;; larger vectors, may not work in Schemes which don’t provide full
+;; Unicode support.
+;;
+;; The list of BMP blocks ends before the surrogate pairs because some
+;; Schemes (arguably correctly) don’t allow unpaired surrogates as
+;; character objects.
+(define low-bmp-block-starts
+  #(#\null #\x80 #\x100 #\x180 #\x250 #\x2B0 #\x300 #\x370 #\x400
+    #\x500 #\x530 #\x590 #\x600 #\x700 #\x750 #\x780 #\x7C0 #\x800
+    #\x840 #\x860 #\x8A0 #\x900 #\x980 #\xA00 #\xA80 #\xB00 #\xB80
+    #\xC00 #\xC80 #\xD00 #\xD80 #\xE00 #\xE80 #\xF00 #\x1000 #\x10A0
+    #\x1100 #\x1200 #\x1380 #\x13A0 #\x1400 #\x1680 #\x16A0 #\x1700
+    #\x1720 #\x1740 #\x1760 #\x1780 #\x1800 #\x18B0 #\x1900 #\x1950
+    #\x1980 #\x19E0 #\x1A00 #\x1A20 #\x1AB0 #\x1B00 #\x1B80 #\x1BC0
+    #\x1C00 #\x1C50 #\x1C80 #\x1C90 #\x1CC0 #\x1CD0 #\x1D00 #\x1D80
+    #\x1DC0 #\x1E00 #\x1F00 #\x2000 #\x2070 #\x20A0 #\x20D0 #\x2100
+    #\x2150 #\x2190 #\x2200 #\x2300 #\x2400 #\x2440 #\x2460 #\x2500
+    #\x2580 #\x25A0 #\x2600 #\x2700 #\x27C0 #\x27F0 #\x2800 #\x2900
+    #\x2980 #\x2A00 #\x2B00 #\x2C00 #\x2C60 #\x2C80 #\x2D00 #\x2D30
+    #\x2D80 #\x2DE0 #\x2E00 #\x2E80 #\x2F00 #\x2FF0 #\x3000 #\x3040
+    #\x30A0 #\x3100 #\x3130 #\x3190 #\x31A0 #\x31C0 #\x31F0 #\x3200
+    #\x3300 #\x3400 #\x4DC0 #\x4E00 #\xA000 #\xA490 #\xA4D0 #\xA500
+    #\xA640 #\xA6A0 #\xA700 #\xA720 #\xA800 #\xA830 #\xA840 #\xA880
+    #\xA8E0 #\xA900 #\xA930 #\xA960 #\xA980 #\xA9E0 #\xAA00 #\xAA60
+    #\xAA80 #\xAAE0 #\xAB00 #\xAB30 #\xAB70 #\xABC0 #\xAC00 #\xD7B0))
+
+(test-group "Bisections over larger vectors of non-numbers"
+  (test "find the number of the Unicode block for schwa"
+        4 (- (vector-bisect-right low-bmp-block-starts #\x259 char<?) 1))
+  (test "find the number of the Unicode block for Devanagari long a"
+        21 (- (vector-bisect-right low-bmp-block-starts #\x906 char<?) 1))
+  (test "find the number of the Unicode block for em dash"
+        71 (- (vector-bisect-right low-bmp-block-starts #\x2014 char<?) 1))
+  (test "find the number of the Unicode block for Cherokee small he"
+        144 (- (vector-bisect-right low-bmp-block-starts #\xAB7E char<?) 1)))
 
 ;; Example of a vector with negative indexes: the mvector accessor for
 ;; a vector guarantees that index 0 will always refer to the median

--- a/test.scm
+++ b/test.scm
@@ -1,0 +1,97 @@
+(import (scheme base))
+(import (scheme division))
+(import (scheme inexact))
+
+(import (chibi test))
+
+(include "srfi-223.scm")
+
+
+;; OEIS A003056
+(define (nth-inverted-triangular n)
+  ;; The OEIS formula yields the sequence 0, 1, 2, 2, 3, 3, 3, ...
+  ;; instead of 0, 1, 1, 2, 2, 2, 3, 3, 3, 3 ..., so this is
+  ;; implemented in terms of A002024, which makes it correct.
+  (- (floor (+ 1/2 (exact (sqrt (* 2 (+ n 1)))))) 1))
+(define (inverted-triangular-ref _ n) (nth-inverted-triangular n))
+
+(test-group "Generalized bisection procedures"
+  (test "left bisection for n for the nth inverted triangular number ≥ x."
+        3 (bisect-left #f 2 inverted-triangular-ref < 0 100))
+  (test "right bisection for n for the nth inverted triangular number < x."
+        6 (bisect-right #f 2 inverted-triangular-ref < 0 100)))
+
+(test-group "Bisections over vectors"
+  (test "left bisection over a vector"
+        1 (vector-bisect-left #(1 2 2 3 5) 2 <))
+  (test "right bisection over a vector"
+        3 (vector-bisect-right #(1 2 2 3 5) 2 <)))
+
+(test-group "Bisections over vectors of things other than numbers"
+  (test "left bisection over a vector of characters"
+        1 (vector-bisect-left #(#\A #\Z #\a #\z) #\B char<?))
+  (test "right bisection over a vector of characters"
+        2 (vector-bisect-right #(#\A #\Z #\a #\z) #\Z char<?)))
+
+;; Example of a vector with negative indexes: the mvector accessor for
+;; a vector guarantees that index 0 will always refer to the median
+;; value in the vector, provided the vector is sorted.
+(define-record-type <mvector>
+  (vector->mvector vector)
+  mvector?
+  (vector mvector-vector mvector-vector-set!))
+
+(define (mvector . vals)
+  (vector->mvector (apply vector vals)))
+
+(define (mvector-size mvector) (vector-length (mvector-vector mvector)))
+(define (mvector-first-idx mvector)
+  (- (floor-quotient (mvector-size mvector) 2)))
+(define (mvector-last-idx mvector)
+  (- (ceiling-quotient (mvector-size mvector) 2)
+     1))
+(define (mvector-ref mvector idx)
+  (vector-ref (mvector-vector mvector)
+              (+ (abs (mvector-first-idx mvector)) idx)))
+
+(define-values (mvector-bisect-left mvector-bisect-right)
+  (bisection mvector-ref
+             (lambda (mv)
+               (values (mvector-first-idx mv)
+                       (+ 1 (mvector-last-idx mv))))))
+
+(define mvtest-even (mvector 1 1 2 3 5 8 13 21))
+(define mvtest-odd (mvector 1 1 2 3 5 8 13 21 34))
+
+(test-group "Implementation of example sequence type with negative indexes"
+  (test "first-idx of even-sized mvector" -4 (mvector-first-idx mvtest-even))
+  (test "first-idx of odd-sized mvector" -4 (mvector-first-idx mvtest-odd))
+
+  (test "last-idx of even-size mvector" 3 (mvector-last-idx mvtest-even))
+  (test "last-idx of odd-size mvector" 4 (mvector-last-idx mvtest-odd))
+
+  (test "min value of even-sized mvector"
+        1 (mvector-ref mvtest-even (mvector-first-idx mvtest-even)))
+  (test "min value of odd-sized mvector"
+        1 (mvector-ref mvtest-odd (mvector-first-idx mvtest-odd)))
+
+  (test "max value of even-sized mvector"
+        21 (mvector-ref mvtest-even (mvector-last-idx mvtest-even)))
+  (test "max value of odd-sized mvector"
+        34 (mvector-ref mvtest-odd (mvector-last-idx mvtest-odd)))
+
+  (test "median value of odd-sized mvector"
+        5 (mvector-ref mvtest-odd 0))
+  (test "median value of even-sized mvector"
+        5 (mvector-ref mvtest-even 0)))
+
+(test-group "Bisection of sequence type with negative indexes"
+  (test "left bisection returning negative result"
+        -2 (mvector-bisect-left mvtest-odd 2 <))
+  (test "right bisection returning negative result"
+        -2 (mvector-bisect-right mvtest-odd 2 <))
+
+  (test "left bisection returning positive result"
+        1 (mvector-bisect-left mvtest-odd 8 <))
+  (test "right bisection returning positive result"
+        2 (mvector-bisect-right mvtest-odd 9 <)))

--- a/test.scm
+++ b/test.scm
@@ -89,7 +89,7 @@
   (test "left bisection returning negative result"
         -2 (mvector-bisect-left mvtest-odd 2 <))
   (test "right bisection returning negative result"
-        -2 (mvector-bisect-right mvtest-odd 2 <))
+        -1 (mvector-bisect-right mvtest-odd 2 <))
 
   (test "left bisection returning positive result"
         1 (mvector-bisect-left mvtest-odd 8 <))


### PR DESCRIPTION
The third draft makes the spec language clearer and stricter on some points and corrects a stupid bug  in the sample implementation (copy-and-paste isn’t your friend, sometimes …).

There's also now a test suite, which is hopefully correct, and should catch implementations out on points where they might trip up, such as integer overflows with large sequences, sequence types with elements at negative indexes, and use of Scheme’s built-in `<` instead of the specified `less?` procedure.
